### PR TITLE
Set font-size for table to 7.0 for the RVV C intrinsics specification

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -231,7 +231,7 @@ table:
   #head_background_color: <hex value>
   #head_font_color: $base_font_color
   head_font_style: bold
-  font-size: 9.0
+  font-size: 7.0
   #body_background_color: <hex value>
   body_stripe_background_color: d7d7d7
   foot_background_color: f0f0f0


### PR DESCRIPTION
Hi Bill @wmat  , this changes is needed for the intrinsics specification.