### PR TITLE
Fix asciidoctor-pdf theme attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To build using the RISC-V template, this statement needs to look like this:
 asciidoctor-pdf \
   -a toc \
   -a compress \
-  -a pdf-style=docs-resources/themes/riscv-pdf.yml \
+  -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
   -a pdf-fontsdir=docs-resources/fonts \
   -o $@ $<
 ```


### PR DESCRIPTION
Update command in README. It's the same update of the [PR](https://github.com/riscv/docs-spec-template/pull/15) in docs-spec-template.