### PR TITLE
Increase font size in tables.

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -232,7 +232,7 @@ table:
   #head_background_color: <hex value>
   #head_font_color: $base_font_color
   head_font_style: bold
-  font-size: 7.0
+  font-size: 11.5
   #body_background_color: <hex value>
   body_stripe_background_color: d7d7d7
   foot_background_color: f0f0f0


### PR DESCRIPTION
7.0 is way too small, it looks weird. Just match the size in the text, which was presumably chosen to be the most readable.