### PR TITLE
Use a non-deprecated icon name for notes

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -156,7 +156,7 @@ admonition:
   padding: [0, $horizontal_rhythm, 0, $horizontal_rhythm]
   icon:
     note:
-      name: pencil-square-o
+      name: far-edit
       stroke_color: 6489b3
     tip:
       name: comments-o


### PR DESCRIPTION
This fixes warnings when building PDFs:
INFO: note admonition in theme uses icon from deprecated fa icon set; use fas, far, or fab instead

Looking at prawn-icon, far-edit is the correct replacement: https://github.com/jessedoyle/prawn-icon/blob/e76a2934237f97121fe93223cf5c71499624a594/data/fonts/fa4/shims.yml#L294C1-L295C1

Fixes https://github.com/riscv/docs-resources/issues/6