### PR TITLE
Change font_size_min to 0.75

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -66,7 +66,7 @@ base:
   font_style: normal
   font_size_large: round($base_font_size * 1.25)
   font_size_small: round($base_font_size * 0.85)
-  font_size_min: 0.75em
+  font_size_min: 0.75
   border_radius: 3
   border_width: 0.25
   border_color: EEEEEE


### PR DESCRIPTION
As asciidoctor-pdf requires a number for base_font_size_min, updating from 0.75em to 0.75.