### PR TITLE
Fix missing bold_italic font

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -16,6 +16,7 @@ font:
       normal: Montserrat-Regular.ttf
       italic: Montserrat-Italic.ttf
       bold: Montserrat-Medium.ttf
+      bold_italic: Montserrat-MediumItalic.ttf
       light: Montserrat-Light.ttf
     code:
       normal: cmunbtl.ttf


### PR DESCRIPTION
This was broken in 75584724da23f0c1ae8b5dbfc788e410493b89c4 and has caused all dependabot PRs
in spec repositories such as riscv-cheri to be broken ever since.

See e.g. https://github.com/riscv/riscv-cheri/pull/630