### PR TITLE
Improvements to Ruby script to create normative rules and addition of JSON schema files

### DIFF
--- a/normative-rules.md
+++ b/normative-rules.md
@@ -46,9 +46,28 @@ AsciiDoc supports several styles of anchors:
     >
     > `This isn't part of the anchor since it is the next paragraph.`
 
-* You can also use the _paragraph anchor_ for table cells and list items if placed before the text such as:
-
-    > `| [[foo]] Here is the table cell contents | next cell`
+* You must use the _paragraph anchor_ for table cells, list items, or description list terms
+  * For table cells and list items, put the anchor before its associated text as follows:
+    * Table cell<br>
+    > `| [[foo]] Here are the table cell contents | next cell`
+    * List item<br>
+    > `* [[foo]] Here is the list item`
+  * For description list terms (e.g., `Apples`, `Oranges`), put the anchor immediately after the term on its own line as follows:
+    > `Apples::`<br>
+    > `[[apple-colors]]`<br>
+    > `Typically be red, yellow, or green.`<br>
+    > <br>
+    > `Oranges:: Generally orange in color`<br>
+    > <br>
+    > `Bananas::`<br>
+    > `[[banana-color]]`<br>
+    > `Generally yellow in color`
+    * These won't work
+    > * `Bananas:: [[banana-color]] Generally yellow in color`<br>
+    > * `[[banana-color]] Bananas:: Generally yellow in color`
+    > * `[[banana-color]]`<br>
+    > `Bananas::`<br>
+    > `Generally yellow in color`
 
 Naming restrictions:
 * Start anchor names with a letter and use `:` to separate fields in the anchor name. No spaces allowed in name.
@@ -67,27 +86,32 @@ If you'd like to get more detailed AsciiDoc information on anchors, please read:
     > Syntax:      `[#<anchor-name>]# ... #`<br>
     > Example:     `Here is an example of [#foo]#anchoring part# of a paragraph
     >              and can have [#bar]#multiple anchors# if needed.`<br>
-    > Tagged text: `anchoring part` and `multiple anchors`
+    > Tagged text: `anchoring part` and `multiple anchors`<br>
+    >
+    > Limitations:
+    > * Can't anchor text across multiple paragraphs.
+    > * Can't use in table cells, list items, or description list items (see #3 below for work-around).
+    > * Must have text next to the 2nd hash symbol (i.e., can't have newline after `[#<anchor-name]#`).
+    > * Can't put inside admonitions such as [NOTE] (see #5 below for solution).
+    > * Can't have `.` in anchor-name (replace with `-`)
 
-2. Limitations:
-* Can't anchor text across multiple paragraphs.
-* Must have text next to the 2nd hash symbol (i.e., can't have newline after `[#<anchor-name]#`).
-* Can't put inside admonitions such as [NOTE] (see #5 below for solution).
-* Can't have `.` in anchor-name (replace with `-`)
-
-3. Anchor to entire paragraph
+2. Anchor to entire paragraph
 
     > Syntax:     `[[<anchor-name]]`<br>
     > Example:    `[[zort]]`<br>
     >             `Here is an example of anchoring a whole paragraph.`<br>
     > Tagged text: Entire paragraph<br>
 
-4. Anchor to entire table cell or a list entry
+3. Anchor to entire table cell, list entry, or description list entry
 
     > Example:    `| Alan Turing | [[Alan_Turing_Birthday]] June 23, 1912 | London`<br>
     > Tagged text: None (just creates hyperlink to anchor in table/list so not so useful)
+    >
+    > Limitations:
+    >  * Anchor must be to entire contents of cell/item.
+    >  * Only one anchor per cell/item.
 
-5. Anchor inside admonition (e.g. `[NOTE]`):
+4. Anchor inside admonition (e.g. `[NOTE]`):
 * Must use `[[<anchor-name]]` before each paragraph (with unique anchor names of course) being tagged
 * Can't use `[#<anchor-name]#Here's some note text.#` since it just shows up in HTML as normal text
 * Don't put `[[<<anchor-name]]` before the entire admonition (e.g., before `[NOTE]`) to apply to entire admonition

--- a/schemas/common-schema.json
+++ b/schemas/common-schema.json
@@ -3,19 +3,31 @@
 
   "title": "Common content used by multiple schemas (reduces copy & paste)",
 
+  "summaryDesc": {
+    "description": "Short summary of the normative rule (just a few words)"
+  },
+  "descriptionDesc": {
+    "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+  },
+  "kindRuleDesc": {
+    "description": "The kind of ISA object associated with this normative rule"
+  },
+  "instancesRuleDesc": {
+    "description": "The names of ISA object instances of the specified kind associated with this normative rule"
+  },
   "stringArray": {
     "type": "array",
     "items": { "type": "string" }
-  },
-  "isaObjectKind":  {
-    "type": "string",
-    "enum": ["extension", "instruction", "csr", "csr_field"]
   },
   "ruleNamePattern" : {
     "pattern": "^[a-zA-z][a-zA-z0-9_-]+$"
   },
   "tagNamePattern" : {
     "pattern": "^[a-zA-z][:a-zA-z0-9_-]+$"
+  },
+  "isaObjectKind":  {
+    "type": "string",
+    "enum": ["extension", "instruction", "csr", "csr_field"]
   },
   "ruleName": {
     "type": "string",

--- a/schemas/common-schema.json
+++ b/schemas/common-schema.json
@@ -7,7 +7,7 @@
     "description": "Short summary of the normative rule (just a few words)"
   },
   "descriptionDesc": {
-    "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+    "description": "Comprehensive description of the normative rule (sentence, paragraph, or longer)"
   },
   "kindRuleDesc": {
     "description": "The kind of ISA object associated with this normative rule"

--- a/schemas/common-schema.json
+++ b/schemas/common-schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Common content used by multiple schemas (reduces copy & paste)",
+
+  "stringArray": {
+    "type": "array",
+    "items": { "type": "string" }
+  },
+  "isaObjectKind":  {
+    "type": "string",
+    "enum": ["extension", "instruction", "csr", "csr_field"]
+  },
+  "ruleNamePattern" : {
+    "pattern": "^[a-zA-z][a-zA-z0-9_-]+$"
+  },
+  "tagNamePattern" : {
+    "pattern": "^[a-zA-z][:a-zA-z0-9_-]+$"
+  },
+  "ruleName": {
+    "type": "string",
+    "$ref": "#/ruleNamePattern"
+  },
+  "ruleNameArray": {
+    "type": "array",
+    "items": {
+      "type": "string",
+      "$ref": "#/ruleNamePattern"
+    }
+  },
+  "tagName": {
+    "type": "string",
+    "$ref": "#/tagNamePattern"
+  },
+  "tagObject": {
+    "type": "object",
+    "properties": {
+      "name": { "$ref": "#/tagName" },
+      "kind": {
+        "$ref": "#/isaObjectKind",
+        "description": "The kind of ISA object associated with this tag"
+      },
+      "instances": {
+        "$ref": "#/stringArray",
+        "description": "The names of ISA object instances of the specified kind associated with this tag"
+      }
+    },
+    "required": ["name"],
+    "additionalProperties": false
+  },
+  "tagArray": {
+    "type": "array",
+    "items": {
+      "anyOf": [
+        { "$ref": "#/tagName" },
+        { "$ref": "#/tagObject" }
+      ]
+    }
+  }
+}

--- a/schemas/defs-schema.json
+++ b/schemas/defs-schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for Normative Rule Definitions - *.yaml files in this directory",
+  "type": "object",
+
+  "properties": {
+    "normative_rule_definitions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "$ref": "common-schema.json#/ruleName",
+            "description": "Single normative rule name"
+          },
+          "names": {
+            "$ref": "common-schema.json#/ruleNameArray",
+            "description": "Multiple normative rule names"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of the normative rule (just a few words)"
+          },
+          "description": {
+            "type": "string",
+            "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+          },
+          "kind": {
+            "$ref": "common-schema.json#/isaObjectKind",
+            "description": "The kind of ISA object associated with this normative rule"
+          },
+          "instances": {
+            "$ref": "common-schema.json#/stringArray",
+            "description": "The names of ISA object instances of the specified kind associated with this normative rule"
+          },
+          "tags": {
+            "$ref": "common-schema.json#/tagArray",
+            "description": "List of normative rule tags that have normative text from adoc files"
+          },
+          "tags_without_text": {
+            "$ref": "common-schema.json#/tagArray",
+            "description": "List of normative rule tags that don't have normative text (just an anchor) from adoc files"
+          }
+        },
+        "oneOf": [
+          { "required": ["name"] },
+          { "required": ["names"] }
+        ],
+        "anyOf": [
+          { "required": ["tags"] },
+          { "required": ["tags_without_text"] }
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["normative_rule_definitions"]
+}

--- a/schemas/defs-schema.json
+++ b/schemas/defs-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Schema for Normative Rule Definitions - *.yaml files in this directory",
+  "title": "Schema for normative rule definitions input files",
   "type": "object",
 
   "properties": {
@@ -19,19 +19,23 @@
           },
           "summary": {
             "type": "string",
-            "description": "Short summary of the normative rule (just a few words)"
+            "$ref": "common-schema.json#/summaryDesc"
           },
           "description": {
             "type": "string",
-            "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+            "$ref": "common-schema.json#/descriptionDesc"
           },
           "kind": {
-            "$ref": "common-schema.json#/isaObjectKind",
-            "description": "The kind of ISA object associated with this normative rule"
+            "allOf": [
+              { "$ref": "common-schema.json#/isaObjectKind" },
+              { "$ref": "common-schema.json#/kindRuleDesc" }
+            ]
           },
           "instances": {
-            "$ref": "common-schema.json#/stringArray",
-            "description": "The names of ISA object instances of the specified kind associated with this normative rule"
+            "allOf": [
+              { "$ref": "common-schema.json#/stringArray" },
+              { "$ref": "common-schema.json#/instancesRuleDesc" }
+            ]
           },
           "tags": {
             "$ref": "common-schema.json#/tagArray",

--- a/schemas/norm-rules-schema.json
+++ b/schemas/norm-rules-schema.json
@@ -19,37 +19,41 @@
           },
           "summary": {
             "type": "string",
-            "description": "Short summary of the normative rule (just a few words)"
+            "$ref": "common-schema.json#/summaryDesc"
           },
           "description": {
             "type": "string",
-            "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+            "$ref": "common-schema.json#/descriptionDesc"
           },
           "kind": {
-            "$ref": "common-schema.json#/isaObjectKind",
-            "description": "The kind of ISA object associated with this normative rule"
+            "allOf": [
+              { "$ref": "common-schema.json#/isaObjectKind" },
+              { "$ref": "common-schema.json#/kindRuleDesc" }
+            ]
           },
           "instances": {
-            "$ref": "common-schema.json#/stringArray",
-            "description": "The names of ISA object instances of the specified kind associated with this normative rule"
+            "allOf": [
+              { "$ref": "common-schema.json#/stringArray" },
+              { "$ref": "common-schema.json#/instancesRuleDesc" }
+            ]
           },
           "tags": {
             "type": "array",
-            "description": "List of normative rule tags that reference the ISA manuals",
+            "description": "List of normative rule tags that reference the standard",
             "items": {
               "type": "object",
               "properties": {
                 "name": {
                   "$ref": "common-schema.json#/tagName",
-                  "description": "Name of the tag (an anchor in the ISA manual adoc files)"
+                  "description": "Name of the tag (an anchor in the standard's adoc files)"
                 },
                 "text": {
                   "type": "string",
-                  "description": "The text from the ISA manual associated with this tag (optional)"
+                  "description": "The text from the standard associated with this tag"
                 },
                 "tag_filename": {
                   "type": "string",
-                  "description": "Tag file that contains maps tag names to tag text (optional)"
+                  "description": "Tag file that maps tag names to tag text"
                 }
               },
               "required": ["name"]

--- a/schemas/norm-rules-schema.json
+++ b/schemas/norm-rules-schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema for norm-rules.json in build directory. Created by build-norm-rules Makefile target.",
+  "type": "object",
+
+  "properties": {
+    "normative_rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+           "$ref": "common-schema.json#/ruleName",
+           "description": "Normative rule name"
+          },
+          "def_filename": {
+            "type": "string",
+            "description": "Normative rule definition file that defines this rule"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short summary of the normative rule (just a few words)"
+          },
+          "description": {
+            "type": "string",
+            "description": "Complete description of the normative rule (sentence, paragraph, or longer)"
+          },
+          "kind": {
+            "$ref": "common-schema.json#/isaObjectKind",
+            "description": "The kind of ISA object associated with this normative rule"
+          },
+          "instances": {
+            "$ref": "common-schema.json#/stringArray",
+            "description": "The names of ISA object instances of the specified kind associated with this normative rule"
+          },
+          "tags": {
+            "type": "array",
+            "description": "List of normative rule tags that reference the ISA manuals",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "$ref": "common-schema.json#/tagName",
+                  "description": "Name of the tag (an anchor in the ISA manual adoc files)"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "The text from the ISA manual associated with this tag (optional)"
+                },
+                "tag_filename": {
+                  "type": "string",
+                  "description": "Tag file that contains maps tag names to tag text (optional)"
+                }
+              },
+              "required": ["name"]
+            }
+          }
+        },
+        "required": ["name", "def_filename"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["normative_rules"],
+  "additionalProperties": false
+}

--- a/tools/create_normative_rules.rb
+++ b/tools/create_normative_rules.rb
@@ -357,7 +357,7 @@ def create_curated_rules(tags, curations)
 
           if tag.nil?
             missing_tag_cnt = missing_tag_cnt + 1
-            info("Normative rule #{curation.name} references non-existant tag #{tag_ref_name}")
+            info("Normative rule #{curation.name} in file #{curation.filename} references non-existant tag #{tag_ref_name}")
           else
             resolved_tag = {
               "tag_name" => tag.tag_name,

--- a/tools/create_normative_rules.rb
+++ b/tools/create_normative_rules.rb
@@ -143,8 +143,8 @@ class NormativeRuleDef
   attr_reader :name                   # String (mandatory)
   attr_reader :summary                # String (optional - a few words)
   attr_reader :description            # String (optional - sentence, paragraph, or more)
-  attr_reader :type                   # String (optional, can be nil, extension, instruction, csr, csr_field)
-  attr_reader :instances              # Array<String> (optional only if type defined, nil if type nil, otherwise an array)
+  attr_reader :kind                   # String (optional, can be nil, extension, instruction, csr, csr_field)
+  attr_reader :instances              # Array<String> (optional only if kind defined, nil if kind nil, otherwise an array)
   attr_reader :tag_refs               # Array<NormativeTagRef> (optional - can be empty)
   attr_reader :tag_refs_without_text  # Array<NormativeTagRef> (optional - can be empty - like tag_refs but no tag text)
 
@@ -166,18 +166,18 @@ class NormativeRuleDef
       fatal_error("Provided #{@description.class} class for description in normative rule #{name} but need a String") unless @description.is_a?(String)
     end
 
-    @type = data["type"]
-    unless @type.nil?
-      fatal_error("Provided #{@type.class} class for type in normative rule #{name} but need a String") unless @type.is_a?(String)
-      check_allowed_types(@type, @name, nil)
+    @kind = data["kind"]
+    unless @kind.nil?
+      fatal_error("Provided #{@kind.class} class for kind in normative rule #{name} but need a String") unless @kind.is_a?(String)
+      check_allowed_types(@kind, @name, nil)
     end
 
     @instances = data["instances"]
-    if @type.nil?
-      # Not allowed to have instances without a type.
-      fatal_error("Normative rule #{name} defines instances but no type") unless @instances.nil?
+    if @kind.nil?
+      # Not allowed to have instances without a kind.
+      fatal_error("Normative rule #{name} defines instances but no kind") unless @instances.nil?
     else
-      fatal_error("Provided #{@type.class} class for type in normative rule #{name} but need a String") unless @type.is_a?(String)
+      fatal_error("Provided #{@kind.class} class for kind in normative rule #{name} but need a String") unless @kind.is_a?(String)
 
       if @instances.nil?
         @instances = []
@@ -201,8 +201,8 @@ end # class NormativeRuleDef
 # Holds one reference to a tag by a rule definition.
 class NormativeTagRef
   attr_reader :name               # String (mandatory)
-  attr_reader :type               # String (optional, can be nil, extension, instruction, csr, csr_field)
-  attr_reader :instances          # Array<String> (optional only if type defined, nil if type nil, otherwise an array)
+  attr_reader :kind               # String (optional, can be nil, extension, instruction, csr, csr_field)
+  attr_reader :instances          # Array<String> (optional only if kind defined, nil if kind nil, otherwise an array)
 
   # The nr_name is the name of the normative rule
   # The data can either be a String (so just the tag name provided) or a hash if more info passed.
@@ -218,19 +218,19 @@ class NormativeTagRef
       fatal_error("Provided #{@name.class} class for tag name #{@name} in normative rule #{nr_name} but need a String") unless @name.is_a?(String)
 
       # Handle optional values
-      @type = data["type"]
-      unless @type.nil?
-        fatal_error("Provided #{@type.class} class for type in tag #{@name} in normative rule #{name} but need a String") unless @type.is_a?(String)
-        check_allowed_types(@type, nr_name, @name)
+      @kind = data["kind"]
+      unless @kind.nil?
+        fatal_error("Provided #{@kind.class} class for kind in tag #{@name} in normative rule #{name} but need a String") unless @kind.is_a?(String)
+        check_allowed_types(@kind, nr_name, @name)
       end
 
       @instances = data["instances"]
 
-      if @type.nil?
-        # Not allowed to have instances without a type.
-        fatal_error("Tag #{@name} referenced in normative rule #{nr_name} defines instances but no type") unless @instances.nil?
+      if @kind.nil?
+        # Not allowed to have instances without a kind.
+        fatal_error("Tag #{@name} referenced in normative rule #{nr_name} defines instances but no kind") unless @instances.nil?
       else
-        fatal_error("Provided #{@type.class} class for type in tag #{name} in normative rule #{nr_name} but need a String") unless @type.is_a?(String)
+        fatal_error("Provided #{@kind.class} class for kind in tag #{name} in normative rule #{nr_name} but need a String") unless @kind.is_a?(String)
 
         if @instances.nil?
           @instances = []
@@ -244,14 +244,14 @@ class NormativeTagRef
   end
 end # class NormativeTagRef
 
-# Create fatal_error if type not recognized. The name is nil if this is called in the normative rule definition.
-def check_allowed_types(type, nr_name, name)
+# Create fatal_error if kind not recognized. The name is nil if this is called in the normative rule definition.
+def check_allowed_types(kind, nr_name, name)
   allowed_types = ["extension", "instruction", "csr", "csr_field"]
 
-  unless allowed_types.include?(type)
+  unless allowed_types.include?(kind)
     tag_str = name.nil? ? "" : "tag #{name} in "
     allowed_str = allowed_types.join(",")
-    fatal_error("Don't recognize type '#{type}' for #{tag_str}normative rule #{nr_name}\n#{PN}: Allowed types are: #{allowed_str}")
+    fatal_error("Don't recognize kind '#{kind}' for #{tag_str}normative rule #{nr_name}\n#{PN}: Allowed types are: #{allowed_str}")
   end
 end
 
@@ -427,7 +427,7 @@ def create_normative_rules(tags, defs)
       }
 
       # Now add optional arguments.
-      hash["type"] = d.type unless d.type.nil?
+      hash["kind"] = d.kind unless d.kind.nil?
       hash["instances"] = d.instances unless d.instances.nil?
       hash["summary"] = d.summary unless d.summary.nil?
       hash["description"] = d.description unless d.description.nil?
@@ -455,7 +455,7 @@ def create_normative_rules(tags, defs)
             }
 
             # Add optional info from tag reference.
-            resolved_tag["type"] = tag_ref.type unless tag_ref.type.nil?
+            resolved_tag["kind"] = tag_ref.kind unless tag_ref.kind.nil?
             resolved_tag["instances"] = tag_ref.instances unless tag_ref.instances.nil?
 
             hash["tags"].append(resolved_tag)
@@ -480,7 +480,7 @@ def create_normative_rules(tags, defs)
             }
 
             # Add optional info from tag reference.
-            resolved_tag["type"] = tag_ref.type unless tag_ref.type.nil?
+            resolved_tag["kind"] = tag_ref.kind unless tag_ref.kind.nil?
             resolved_tag["instances"] = tag_ref.instances unless tag_ref.instances.nil?
 
             hash["tags"].append(resolved_tag)

--- a/tools/create_normative_rules.rb
+++ b/tools/create_normative_rules.rb
@@ -20,33 +20,33 @@ class NormativeTags
 
   # Add tags for specified standards document.
   #
-  # param filename [String] Name of the tag file
+  # param tag_filename [String] Name of the tag file
   # param tags [Hash<String,String>] Hash key is tag name (AKA anchor name) and value is tag text.
-  def add_tags(filename, tags)
-    fatal_error("Need String for filename but was passed a #{filename.class}") unless filename.is_a?(String)
+  def add_tags(tag_filename, tags)
+    fatal_error("Need String for tag_filename but was passed a #{tag_filename.class}") unless tag_filename.is_a?(String)
     fatal_error("Need Hash for tags but was passed a #{tags.class}") unless tags.is_a?(Hash)
 
-    tags.each do |tag_name, tag_text|
-      unless tag_name.is_a?(String)
-        fatal_error("NormativeTag name #{tag_name} in file #{filename} is a #{tag_name.class} instead of a String")
+    tags.each do |name, text|
+      unless name.is_a?(String)
+        fatal_error("Tag name #{name} in file #{tag_filename} is a #{name.class} instead of a String")
       end
 
-      unless tag_text.is_a?(String)
-        fatal_error("NormativeTag name #{tag_name} in file #{filename} is a #{tag_text.class} instead of a String
-#{PN}:   If the AsciiDoc anchor for #{tag_name} is before an AsciiDoc 'Description List' term, move to after term on its own line.")
+      unless text.is_a?(String)
+        fatal_error("Tag name #{name} in file #{tag_filename} is a #{text.class} instead of a String
+#{PN}:   If the AsciiDoc anchor for #{name} is before an AsciiDoc 'Description List' term, move to after term on its own line.")
       end
 
-      unless @tag_map[tag_name].nil?
-        fatal_error("NormativeTag name #{tag_name} in file #{filename} already defined in file #{@tag_map[tag_name].filename}")
+      unless @tag_map[name].nil?
+        fatal_error("Tag name #{name} in file #{tag_filename} already defined in file #{@tag_map[name].tag_filename}")
       end
 
-      @tag_map[tag_name] = NormativeTag.new(tag_name, filename, tag_text)
+      @tag_map[name] = NormativeTag.new(name, tag_filename, text)
     end
   end
 
   # @param [String] Normative rule tag name
   # @return [NormativeTag] Normative rule tag object corresponding to tag name. Returns nil if not found.
-  def get_tag(tag_name) = @tag_map[tag_name]
+  def get_tag(name) = @tag_map[name]
 
   # @return [Array<NormativeTag>] All normative tags for the standard.
   def get_tags() = @tag_map.values
@@ -55,25 +55,25 @@ end
 # Holds all information for one tag.
 class NormativeTag
   # @return [String] Name of normative rule tag into standards document
-  attr_reader :tag_name
+  attr_reader :name
 
-  # @return [String] Name of standards document tag is located in.
-  attr_reader :filename
+  # @return [String] Name of tag file
+  attr_reader :tag_filename
 
   # @return [String] Text associated with normative rule tag from standards document. Can have newlines.
-  attr_reader :tag_text
+  attr_reader :text
 
-  # @param tag_name [String]
-  # @param filename [String]
-  # @param tag_text [String]
-  def initialize(tag_name, filename, tag_text)
-    fatal_error("Need String for tag_name but passed a #{tag_name.class}") unless tag_name.is_a?(String)
-    fatal_error("Need String for filename but passed a #{filename.class}") unless filename.is_a?(String)
-    fatal_error("Need String for tag_text but passed a #{tag_text.class}") unless tag_text.is_a?(String)
+  # @param name [String]
+  # @param tag_filename [String]
+  # @param text [String]
+  def initialize(name, tag_filename, text)
+    fatal_error("Need String for name but passed a #{name.class}") unless name.is_a?(String)
+    fatal_error("Need String for tag_filename but passed a #{tag_filename.class}") unless tag_filename.is_a?(String)
+    fatal_error("Need String for text but passed a #{text.class}") unless text.is_a?(String)
 
-    @tag_name = tag_name
-    @filename = filename
-    @tag_text = tag_text
+    @name = name
+    @tag_filename = tag_filename
+    @text = text
 
     # Used to find tags without any references to them.
     @ref_to_me = false
@@ -87,94 +87,171 @@ class NormativeTag
   def unreferenced? = !@ref_to_me
 end
 
-########################################
-# Classes for Normative Rule Creations #
-########################################
+##########################################
+# Classes for Normative Rule Definitions #
+##########################################
 
-# Holds all the information for all the normative rule creation files.
-class NormativeRuleCreations
-  attr_reader :norm_rule_creations  # Array<NormativeRuleCreation> Contains all normative rules across all input files
+# Holds all the information for all normative rule definition files.
+class NormativeRuleDefs
+  attr_reader :norm_rule_defs  # Array<NormativeRuleDef> Contains all normative rule definitions across all input files
 
   def initialize
-    @norm_rule_creations = []
-    @hash = {}     # Hash<String name, NormativeRuleCreation> Same objects as in array and just internal to class
+    @norm_rule_defs = []
+    @hash = {}     # Hash<String name, NormativeRuleDef> Same objects as in array and just internal to class
   end
 
-  def add_file_contents(filename, array_data)
-    fatal_error("Need String for filename but passed a #{filename.class}") unless filename.is_a?(String)
+  def add_file_contents(def_filename, array_data)
+    fatal_error("Need String for def_filename but passed a #{def_filename.class}") unless def_filename.is_a?(String)
     fatal_error("Need Array for array_data but passed a #{array_data.class}") unless array_data.is_a?(Array)
 
     array_data.each do |data|
-      fatal_error("File #{filename} entry isn't a hash: #{data}") unless data.is_a?(Hash)
+      fatal_error("File #{def_filename} entry isn't a hash: #{data}") unless data.is_a?(Hash)
 
       if !data["name"].nil?
-        # Add one creation object
-        add_creation(data["name"], filename, data)
+        # Add one definition object
+        add_def(data["name"], def_filename, data)
       elsif !data["names"].nil?
-        # Add one creation object for each name in array
+        # Add one definition object for each name in array
         names = data["names"]
         names.each do |name|
-          add_creation(name, filename, data)
+          add_def(name, def_filename, data)
         end
       else
-        fatal_error("File #{filename} missing name/names in normative rule creation entry: #{data}")
+        fatal_error("File #{def_filename} missing name/names in normative rule definition entry: #{data}")
       end
     end
   end
 
-  def add_creation(name, filename, data)
+  def add_def(name, def_filename, data)
     fatal_error("Need String for name but passed a #{name.class}") unless name.is_a?(String)
-    fatal_error("Need String for filename but passed a #{filename.class}") unless filename.is_a?(String)
+    fatal_error("Need String for def_filename but passed a #{def_filename.class}") unless def_filename.is_a?(String)
     fatal_error("Need Hash for data but passed a #{data.class}") unless data.is_a?(Hash)
 
     unless @hash[name].nil?
-      fatal_error("Normative rule creation #{name} in file #{filename} already defined in file #{@hash[name].filename}")
+      fatal_error("Normative rule definition #{name} in file #{def_filename} already defined in file #{@hash[name].def_filename}")
     end
 
-    # Create creation object and store reference to it in array (to maintain order) and hash (for convenient lookup by name).
-    norm_rule_creations = NormativeRuleCreation.new(filename, name, data)
-    @norm_rule_creations.append(norm_rule_creations)
-    @hash[name] = norm_rule_creations
+    # Create definition object and store reference to it in array (to maintain order) and hash (for convenient lookup by name).
+    norm_rule_defs = NormativeRuleDef.new(def_filename, name, data)
+    @norm_rule_defs.append(norm_rule_defs)
+    @hash[name] = norm_rule_defs
   end
-end # class NormativeRuleCreations
+end # class NormativeRuleDefs
 
-class NormativeRuleCreation
-  attr_reader :filename               # String (mandatory)
+class NormativeRuleDef
+  attr_reader :def_filename           # String (mandatory)
   attr_reader :name                   # String (mandatory)
-  attr_reader :type                   # String (optional)
   attr_reader :summary                # String (optional - a few words)
   attr_reader :description            # String (optional - sentence, paragraph, or more)
+  attr_reader :type                   # String (optional, can be nil, extension, instruction, csr, csr_field)
+  attr_reader :instances              # Array<String> (optional only if type defined, nil if type nil, otherwise an array)
   attr_reader :tag_refs               # Array<NormativeTagRef> (optional - can be empty)
   attr_reader :tag_refs_without_text  # Array<NormativeTagRef> (optional - can be empty - like tag_refs but no tag text)
 
-  def initialize(filename, name, data)
-    @filename = filename
+  def initialize(def_filename, name, data)
+    fatal_error("Need String for def_filename but was passed a #{def_filename.class}") unless def_filename.is_a?(String)
+    fatal_error("Need String for name but was passed a #{name.class}") unless name.is_a?(String)
+    fatal_error("Need Hash for data but was passed a #{data.class}") unless data.is_a?(Hash)
+
+    @def_filename = def_filename
     @name = name
-    @type = data["type"]
+
     @summary = data["summary"]
+    unless @summary.nil?
+      fatal_error("Provided #{@summary.class} class for summary in normative rule #{name} but need a String") unless @summary.is_a?(String)
+    end
+
     @description = data["description"]
+    unless @description.nil?
+      fatal_error("Provided #{@description.class} class for description in normative rule #{name} but need a String") unless @description.is_a?(String)
+    end
+
+    @type = data["type"]
+    unless @type.nil?
+      fatal_error("Provided #{@type.class} class for type in normative rule #{name} but need a String") unless @type.is_a?(String)
+      check_allowed_types(@type, @name, nil)
+    end
+
+    @instances = data["instances"]
+    if @type.nil?
+      # Not allowed to have instances without a type.
+      fatal_error("Normative rule #{name} defines instances but no type") unless @instances.nil?
+    else
+      fatal_error("Provided #{@type.class} class for type in normative rule #{name} but need a String") unless @type.is_a?(String)
+
+      if @instances.nil?
+        @instances = []
+      else
+        fatal_error("Provided #{@instances.class} class for instances in normative rule #{nr_name} but need an Array") unless @instances.is_a?(Array)
+      end
+    end
 
     @tag_refs = []
     data["tags"]&.each do |tag_data|
-      @tag_refs.append(NormativeTagRef.new(tag_data))
+      @tag_refs.append(NormativeTagRef.new(@name, tag_data))
     end
 
     @tag_refs_without_text = []
     data["tags_without_text"]&.each do |tag_data|
-      @tag_refs_without_text.append(NormativeTagRef.new(tag_data))
+      @tag_refs_without_text.append(NormativeTagRef.new(@name, tag_data))
     end
   end
-end # class NormativeRuleCreation
+end # class NormativeRuleDef
 
-# Holds one reference to a tag by a creation.
+# Holds one reference to a tag by a rule definition.
 class NormativeTagRef
-  attr_reader :name
+  attr_reader :name               # String (mandatory)
+  attr_reader :type               # String (optional, can be nil, extension, instruction, csr, csr_field)
+  attr_reader :instances          # Array<String> (optional only if type defined, nil if type nil, otherwise an array)
 
-  # Currently NormativeTag is just a String but could potentially be passed a Hash if metadata gets added to a tag.
-  def initialize(tag_data)
-    fatal_error("Need String for tag_data but passed a #{tag_data.class}") unless tag_data.is_a?(String)
+  # The nr_name is the name of the normative rule
+  # The data can either be a String (so just the tag name provided) or a hash if more info passed.
+  def initialize(nr_name, data)
+    fatal_error("Need String for nr_name but was passed a #{nr_name.class}") unless nr_name.is_a?(String)
 
-    @name = tag_data
+    if data.is_a?(String)
+      @name = data
+      @instances = nil
+    elsif data.is_a?(Hash)
+      @name = data["name"]
+      fatal_error("Missing tag name referenced by normative rule #{nr_name}") if @name.nil?
+      fatal_error("Provided #{@name.class} class for tag name #{@name} in normative rule #{nr_name} but need a String") unless @name.is_a?(String)
+
+      # Handle optional values
+      @type = data["type"]
+      unless @type.nil?
+        fatal_error("Provided #{@type.class} class for type in tag #{@name} in normative rule #{name} but need a String") unless @type.is_a?(String)
+        check_allowed_types(@type, nr_name, @name)
+      end
+
+      @instances = data["instances"]
+
+      if @type.nil?
+        # Not allowed to have instances without a type.
+        fatal_error("Tag #{@name} referenced in normative rule #{nr_name} defines instances but no type") unless @instances.nil?
+      else
+        fatal_error("Provided #{@type.class} class for type in tag #{name} in normative rule #{nr_name} but need a String") unless @type.is_a?(String)
+
+        if @instances.nil?
+          @instances = []
+        else
+          fatal_error("Provided #{@instances.class} class for instances in tag #{name} in normative rule #{nr_name} but need an Array") unless @instances.is_a?(Array)
+        end
+      end
+    else
+      fatal_error("Need String or Hash for data for normative rule #{nr_name} but passed a #{data.class}")
+    end
+  end
+end # class NormativeTagRef
+
+# Create fatal_error if type not recognized. The name is nil if this is called in the normative rule definition.
+def check_allowed_types(type, nr_name, name)
+  allowed_types = ["extension", "instruction", "csr", "csr_field"]
+
+  unless allowed_types.include?(type)
+    tag_str = name.nil? ? "" : "tag #{name} in "
+    allowed_str = allowed_types.join(",")
+    fatal_error("Don't recognize type '#{type}' for #{tag_str}normative rule #{nr_name}\n#{PN}: Allowed types are: #{allowed_str}")
   end
 end
 
@@ -189,10 +266,10 @@ end
 
 def usage(exit_status = 1)
   puts "Usage: #{PN} [OPTION]... <output-filename>"
-  puts "  -c filename    normative rule creation filename (YAML)"
-  puts "  -t filename    normative tag filename (JSON)"
+  puts "  -d filename    normative rule definition filename (YAML format)"
+  puts "  -t filename    normative tag filename (JSON format)"
   puts
-  puts "Creates list of normative rules and stores them in <output-filename> (in JSON format)."
+  puts "Creates list of normative rules and stores them in <output-filename> (JSON format)."
   exit exit_status
 end
 
@@ -205,20 +282,20 @@ def parse_argv
   usage if ARGV.count == 0
 
   # Return values
-  creation_fnames=[]
+  def_fnames=[]
   tag_fnames=[]
-  output_fname=
+  output_fname=nil
 
   i = 0
   while i < ARGV.count
     arg = ARGV[i]
     case arg
-    when "-c"
+    when "-d"
       if (ARGV.count-i) < 1
-        info("Missing argument for -c option")
+        info("Missing argument for -d option")
         usage
       end
-      creation_fnames.append(ARGV[i+1])
+      def_fnames.append(ARGV[i+1])
       i=i+1
     when "-t"
       if (ARGV.count-i) < 1
@@ -242,8 +319,8 @@ def parse_argv
     i=i+1
   end
 
-  if creation_fnames.empty?
-    info("Missing normative rule creation filename(s)")
+  if def_fnames.empty?
+    info("Missing normative rule definition filename(s)")
     usage
   end
 
@@ -257,7 +334,7 @@ def parse_argv
     usage
   end
 
-  return [creation_fnames, tag_fnames, output_fname]
+  return [def_fnames, tag_fnames, output_fname]
 end
 
 # Load the contents of all normative rule tag files in JSON format.
@@ -267,12 +344,12 @@ def load_tags(tag_fnames)
 
   tags = NormativeTags.new()
 
-  tag_fnames.each do |filename|
-    info("Loading tag file #{filename}")
+  tag_fnames.each do |tag_fname|
+    info("Loading tag file #{tag_fname}")
 
     # Read in file to a String
     begin
-      file_contents = File.read(filename, encoding: "UTF-8")
+      file_contents = File.read(tag_fname, encoding: "UTF-8")
     rescue Errno::ENOENT => e
       fatal_error("#{e.message}")
     end
@@ -281,33 +358,33 @@ def load_tags(tag_fnames)
     begin
       file_data = JSON.parse(file_contents)
     rescue JSON::ParserError => e
-      fatal_error("File #{filename} JSON parsing error: #{e.message}")
+      fatal_error("File #{tag_fname} JSON parsing error: #{e.message}")
     rescue JSON::NestingError => e
-      fatal_error("File #{filename} JSON nesting error: #{e.message}")
+      fatal_error("File #{tag_fname} JSON nesting error: #{e.message}")
     end
 
-    tags_data = file_data["tags"] || fatal_error("Missing 'tags' key in #{filename}")
+    tags_data = file_data["tags"] || fatal_error("Missing 'tags' key in #{tag_fname}")
 
     # Add tags from JSON file to Ruby class.
-    tags.add_tags(filename, tags_data)
+    tags.add_tags(tag_fname, tags_data)
   end
 
   return tags
 end
 
-# Load the contents of all normative rule creation files in YAML format.
-# Returns a NormativeRuleCreation class with all the contents.
-def load_creations(creation_fnames)
-  fatal_error("Need Array<String> for creation_fnames but passed a #{creation_fnames.class}") unless creation_fnames.is_a?(Array)
+# Load the contents of all normative rule definition files in YAML format.
+# Returns a NormativeRuleDef class with all the contents.
+def load_definitions(def_fnames)
+  fatal_error("Need Array<String> for def_fnames but passed a #{def_fnames.class}") unless def_fnames.is_a?(Array)
 
-  creations = NormativeRuleCreations.new()
+  defs = NormativeRuleDefs.new()
 
-  creation_fnames.each do |filename|
-    info("Loading creation file #{filename}")
+  def_fnames.each do |def_fname|
+    info("Loading definition file #{def_fname}")
 
     # Read in file to a String
     begin
-      file_contents = File.read(filename, encoding: "UTF-8")
+      file_contents = File.read(def_fname, encoding: "UTF-8")
     rescue Errno::ENOENT => e
       fatal_error("#{e.message}")
     end
@@ -317,24 +394,24 @@ def load_creations(creation_fnames)
     begin
       yaml_hash = YAML.load(file_contents)
     rescue Psych::SyntaxError => e
-      fatal_error("File #{filename} YAML syntax error - #{e.message}")
+      fatal_error("File #{def_fname} YAML syntax error - #{e.message}")
     end
 
-    array_data = yaml_hash["normative_rule_creations"] || fatal_error("Missing 'normative_rule_creations' key in #{filename}")
-    fatal_error("'normative_rule_creations' isn't an array in #{filename}") unless array_data.is_a?(Array)
+    array_data = yaml_hash["normative_rule_definitions"] || fatal_error("Missing 'normative_rule_definitions' key in #{def_fname}")
+    fatal_error("'normative_rule_definitions' isn't an array in #{def_fname}") unless array_data.is_a?(Array)
 
-    creations.add_file_contents(filename, array_data)
+    defs.add_file_contents(def_fname, array_data)
   end
 
-  return creations
+  return defs
 end
 
 # Returns a Hash with just one entry called "normative_rules" that contains an Array of Hashes of all normative rules.
-def create_normative_rules(tags, creations)
+def create_normative_rules(tags, defs)
     fatal_error("Need NormativeTags for tags but was passed a #{tags.class}") unless tags.is_a?(NormativeTags)
-    fatal_error("Need NormativeRuleCreations for creations but was passed a #{creations.class}") unless creations.is_a?(NormativeRuleCreations)
+    fatal_error("Need NormativeRuleDefs for defs but was passed a #{defs.class}") unless defs.is_a?(NormativeRuleDefs)
 
-    info("Creating created normative rules")
+    info("Creating normative rules from definition files")
 
     ret = {
       "normative_rules" => []
@@ -342,25 +419,26 @@ def create_normative_rules(tags, creations)
 
     missing_tag_cnt = 0
 
-    creations.norm_rule_creations.each do |creation|
-      # Create hash with mandatory creation arguments.
+    defs.norm_rule_defs.each do |d|
+      # Create hash with mandatory definition arguments.
       hash = {
-        "name" => creation.name,
-        "filename" => creation.filename
+        "name" => d.name,
+        "def_filename" => d.def_filename
       }
 
       # Now add optional arguments.
-      hash["type"] = creation.type unless creation.type.nil?
-      hash["summary"] = creation.summary unless creation.summary.nil?
-      hash["description"] = creation.description unless creation.description.nil?
+      hash["type"] = d.type unless d.type.nil?
+      hash["instances"] = d.instances unless d.instances.nil?
+      hash["summary"] = d.summary unless d.summary.nil?
+      hash["description"] = d.description unless d.description.nil?
 
-      unless creation.tag_refs.nil? && creation.tag_refs_without_text.nil?
+      unless d.tag_refs.nil? && d.tag_refs_without_text.nil?
         hash["tags"] = []
       end
 
       # Add tag entries for those that should have tag text.
-      unless creation.tag_refs.nil?
-        creation.tag_refs.each do |tag_ref|
+      unless d.tag_refs.nil?
+        d.tag_refs.each do |tag_ref|
           tag_ref_name = tag_ref.name
 
           # Lookup tag
@@ -368,13 +446,17 @@ def create_normative_rules(tags, creations)
 
           if tag.nil?
             missing_tag_cnt = missing_tag_cnt + 1
-            info("Normative rule #{creation.name} in file #{creation.filename} references non-existant tag #{tag_ref_name}")
+            info("Normative rule #{d.name} defined in file #{d.def_filename} references non-existant tag #{tag_ref_name}")
           else
             resolved_tag = {
-              "tag_name" => tag.tag_name,
-              "tag_text" => tag.tag_text,
-              "filename" => tag.filename
+              "name" => tag.name,
+              "text" => tag.text,
+              "tag_filename" => tag.tag_filename
             }
+
+            # Add optional info from tag reference.
+            resolved_tag["type"] = tag_ref.type unless tag_ref.type.nil?
+            resolved_tag["instances"] = tag_ref.instances unless tag_ref.instances.nil?
 
             hash["tags"].append(resolved_tag)
 
@@ -385,8 +467,8 @@ def create_normative_rules(tags, creations)
       end
 
       # Add tag entries for those that shouldn't have tag text.
-      unless creation.tag_refs_without_text.nil?
-        creation.tag_refs_without_text.each do |tag_ref|
+      unless d.tag_refs_without_text.nil?
+        d.tag_refs_without_text.each do |tag_ref|
           tag_ref_name = tag_ref.name
 
           # Lookup tag. Should be nil.
@@ -394,12 +476,16 @@ def create_normative_rules(tags, creations)
 
           if tag.nil?
             resolved_tag = {
-              "tag_name" => tag_ref_name,
+              "name" => tag_ref_name,
             }
+
+            # Add optional info from tag reference.
+            resolved_tag["type"] = tag_ref.type unless tag_ref.type.nil?
+            resolved_tag["instances"] = tag_ref.instances unless tag_ref.instances.nil?
 
             hash["tags"].append(resolved_tag)
           else
-            fatal_error("Normative rule #{creation.name} in file #{creation.filename} has
+            fatal_error("Normative rule #{d.name} defined in file #{d.def_filename} has
 #{PN}: tag #{tag_ref_name} tag text but shouldn't")
           end
         end
@@ -424,7 +510,7 @@ def detect_unreferenced_tags(tags, normative_rules)
 
   tags.get_tags.each do |tag|
     if tag.unreferenced?
-      info("Tag #{tag.tag_name} not referenced by any normative rule. Did you forget to create a normative rule?")
+      info("Tag #{tag.name} not referenced by any normative rule. Did you forget to define a normative rule?")
       unref_cnt = unref_cnt + 1
     end
   end
@@ -441,7 +527,7 @@ def store_normative_rules(filename, normative_rules)
   nr_array = normative_rules["normative_rules"]
   raise "Expecting an array for key normative_rules but got an #{nr_array.class}" unless nr_array.is_a?(Array)
 
-  info("Storing #{nr_array.count} created normative rules into file #{filename}")
+  info("Storing #{nr_array.count} normative rules into file #{filename}")
 
   # Serialize normative_rules hash to JSON format String.
   # Shouldn't throw exceptions since we created the data being serialized.
@@ -465,15 +551,15 @@ end
 
 info("Passed #{ARGV.join(' ')}")
 
-creation_fnames, tag_fnames, output_fname = parse_argv()
+def_fnames, tag_fnames, output_fname = parse_argv()
 
-info("Normative rule creation filenames = #{creation_fnames}")
+info("Normative rule definition filenames = #{def_fnames}")
 info("Normative tag filenames = #{tag_fnames}")
 info("Output filename = #{output_fname}")
 
 tags = load_tags(tag_fnames)
-creations = load_creations(creation_fnames)
-normative_rules = create_normative_rules(tags, creations)
+defs = load_definitions(def_fnames)
+normative_rules = create_normative_rules(tags, defs)
 detect_unreferenced_tags(tags, normative_rules)
 store_normative_rules(output_fname, normative_rules)
 


### PR DESCRIPTION
I've made several enhancements to the Ruby tool used to create normative rules. I've also added JSON schemas for the normative rule definition YAML input file format and for the normative rule JSON output file format. The YAML files live in the standards repo with its associated adoc files (so just the ISA manual repo for now but I'm planning ahead for other RISC-V non-ISA standards).

I'd like to see this merged into main so I can have the PR to the ISA manual repo get merged (since it depends on the files in docs-resources).