### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
