### PR TITLE
Add bold_italic variant to headings font catalog

### DIFF
--- a/themes/riscv-pdf.yml
+++ b/themes/riscv-pdf.yml
@@ -16,6 +16,7 @@ font:
       normal: Montserrat-Regular.ttf
       italic: Montserrat-Italic.ttf
       bold: Montserrat-Medium.ttf
+      bold_italic: Montserrat-MediumItalic.ttf
       light: Montserrat-Light.ttf
     code:
       normal: cmunbtl.ttf


### PR DESCRIPTION
Register Montserrat-MediumItalic.ttf as the bold_italic variant for the headings font family to prevent Prawn::Errors::UnknownFont when headings contain bold+italic inline markup.