### PR TITLE
Fix comment-title extraction specificity and guard against multi-panel alt-text collapse

### DIFF
--- a/tools/wavedrom_a11y.py
+++ b/tools/wavedrom_a11y.py
@@ -23,9 +23,21 @@ def extract_content(edn_path):
     a11y_desc = a11y_desc_match.group(1).strip() if a11y_desc_match else None
 
     # Try to extract title from section comment (e.g. //## 9.4 Atomic Memory Operations)
-    comment_match = re.search(r'//#+\s*(.+)', content)
-    if comment_match:
-        comment_title = comment_match.group(1).strip()
+    comment_matches = re.findall(r'^(//#+)\s*(.+)', content, re.MULTILINE)
+    if comment_matches:
+        # Prefer the most specific (deepest '#' level) comment, e.g. "///" over "//" or "//##"
+        comment_matches.sort(key=lambda m: len(m[0]), reverse=True)
+        basename = os.path.splitext(os.path.basename(edn_path))[0]
+        norm_basename = re.sub(r'[-_]', '', basename).lower()
+        comment_title = None
+        for _, text in comment_matches:
+            text = text.strip()
+            norm_text = re.sub(r'[-_\s]', '', text).lower()
+            if norm_text != norm_basename:
+                comment_title = text
+                break
+        if comment_title is None:
+            comment_title = comment_matches[0][1].strip()
     else:
         basename = os.path.splitext(os.path.basename(edn_path))[0]
         clean_name = basename.replace('-', ' ').replace('_', ' ')

--- a/tools/wavedrom_a11y.py
+++ b/tools/wavedrom_a11y.py
@@ -119,6 +119,18 @@ def update_edn_alt_text(edn_path, content, title):
     # Escape any double quotes in the title so it doesn't break the attribute string
     safe_title = title.replace('"', '&quot;')
 
+    # Guard: if this file has more than one wavedrom/bytefield macro block,
+    # we can't compute distinct per-panel titles from one file-level title.
+    # Skip rather than silently collapsing all panels to the same alt text.
+    panel_count = len(re.findall(r'\[wavedrom,\s*,\s*svg(?:,\s*alt="[^"]*")?\]', content)) + \
+                  len(re.findall(r'\[bytefield(?:,\s*,\s*svg,\s*alt="[^"]*")?\]', content))
+    if panel_count > 1:
+        print(f"SKIPPED (multi-panel, {panel_count} blocks): {edn_path} - "
+              f"has multiple macro blocks with distinct alt text; "
+              f"automatic single-title substitution would overwrite all of them. "
+              f"Edit alt text manually per panel if needed.")
+        return
+
     updated = content
 
     # wavedrom: [wavedrom, ,svg]  =>  [wavedrom, ,svg, alt="TITLE"]


### PR DESCRIPTION
Contributes to riscv/riscv-isa-manual#1129

## Fix 1: comment-title extraction specificity

`extract_content()` previously used `re.search` to select the first `//#+` comment in a `.edn` file as the diagram title. However, many diagram files contain multiple nested heading levels (for example, `//#` chapter, `//##` section, and `//###` figure), where the first match is usually the least specific.

Example (`float-csr.edn`):
//# "F" Standard Extension for Single-Precision Floating-Point, Version 2.2
//## 12.2 Floating-Point Control and Status Register
//### Figure 12.2: Floating-point control and status register.

Previously, the generated alt text used the first heading (the extension name) instead of the figure title. This affects 13 diagram files in riscv-isa-manual.

Fix: collect all `//#+` comments and select the one with the greatest number of `#` characters (the deepest heading level). If the deepest heading is only a placeholder matching the file's basename (as in `c-cs-format-ls.edn`, where the heading is simply the filename), fall back to the next deepest heading instead.

Verified against all 13 known affected files and a full regression sweep of all 203 `.edn` files in riscv-isa-manual (WaveDrom and Bytefield), with no crashes or empty-title regressions.

## Fix 2: multi-panel alt-text collapse guard

`update_edn_alt_text()`'s fallback substitution path (used when a file already has `alt="..."` set) does an unbounded `re.subn` across the whole file. Some `.edn` files contain multiple `[wavedrom, ,svg, alt="..."]` or `[bytefield, ,svg, alt="..."]` blocks, each with distinct, correct, hand-authored alt text describing a different panel of a multi-panel figure. Because the tool only ever computes one title per file, re-running it on such a file would silently collapse every panel's alt text to the same duplicated title.

This hasn't caused live damage — the affected files' alt text is currently intact — but it's a dormant risk on any future re-run.

Fix: count the macro blocks before substituting; if a file has more than one, skip substitution and print a warning instead of guessing a single title for all panels.

Verified empirically on throwaway copies:
- A known multi-panel file (2 panels, distinct alt text per panel): guard fires, both panels' alt text preserved.
- A known single-panel file: guard does not fire, substitution behaves as before.