### PR TITLE
251 add callable workflow for dco check

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -56,6 +56,7 @@ jobs:
                 'https://github.com/riscv/docs-spec-template/blob/main/CONTRIBUTING.md';
 
               const possiblePaths = [
+                'docs-resources/CONTRIBUTING.md',
                 'CONTRIBUTING.md',
                 '.github/CONTRIBUTING.md',
                 'docs/CONTRIBUTING.md',

--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -1,0 +1,106 @@
+---
+name: DCO Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - converted_to_draft
+  workflow_call:
+
+jobs:
+  dco_check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    steps:
+      - name: Check for DCO
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              console.log('Could not get pull request from context, exiting');
+              return;
+            }
+
+            // Paginate: listCommits returns only the first 30 commits by
+            // default, so a long PR could hide unsigned commits.
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            // Bots (e.g. autofix-ci[bot] pushing regenerated normative rules,
+            // dependabot) cannot sign off their commits, so exclude them from
+            // the DCO requirement. GitHub resolves the author to a user object
+            // whose type is 'Bot' and whose login ends in '[bot]'.
+            const isBot = (user) =>
+              !!user && (user.type === 'Bot' || /\[bot\]$/.test(user.login || ''));
+
+            const dcoFailedCommits = commits.filter(
+              (commit) =>
+                !isBot(commit.author) &&
+                !isBot(commit.committer) &&
+                !/Signed-off-by:/.test(commit.commit.message)
+            );
+
+            if (dcoFailedCommits.length > 0) {
+              let contributingUrl =
+                'https://github.com/riscv/docs-spec-template/blob/main/CONTRIBUTING.md';
+
+              const possiblePaths = [
+                'CONTRIBUTING.md',
+                '.github/CONTRIBUTING.md',
+                'docs/CONTRIBUTING.md',
+              ];
+
+              for (const path of possiblePaths) {
+                try {
+                  const res = await github.rest.repos.getContent({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    path: path,
+                    ref: pr.base.sha || pr.base.ref,
+                  });
+                  if (res.data && res.data.html_url) {
+                    contributingUrl = res.data.html_url;
+                    break;
+                  }
+                } catch (e) {
+                  // File not found at path, continue to next fallback
+                }
+              }
+
+              const comment = [
+                ':warning: DCO CHECK FAILED :warning:',
+                '',
+                "The Developer's Certificate of Origin (DCO) check has failed for this pull request.",
+                'To fix this, you need to sign off on your commits.',
+                '',
+                'For instructions on how to set up signed commits, please see:',
+                contributingUrl,
+                '',
+                'Once you have signed your commits, you will need to force-push your changes.',
+              ].join('\n');
+
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: comment,
+                });
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                core.warning(`Could not post DCO comment: ${message}`);
+              }
+
+              core.setFailed('DCO check failed. One or more commits are not signed off.');
+            }


### PR DESCRIPTION
This just adds a callable dco_check workflow.  It first checks to see if the calling repository has a populated docs-resources submodule with dco_check.yml in it, if yes, it uses it, if not it uses this one.